### PR TITLE
Minor tweak to use conditional rendering instead of empty string

### DIFF
--- a/components/Home/Pricing/GradientCards.tsx
+++ b/components/Home/Pricing/GradientCards.tsx
@@ -19,9 +19,11 @@ const GradientCards = ({ toptext, header, subheader, plans }: Props) => {
     <div className="bg-language mt-14 py-16">
       <div className="mx-auto flex flex-col justify-center px-4 md:px-8">
         <div className="mb-10 md:mb-16">
-          <h2 className="mb-4 text-center text-2xl text-h1title md:mb-6 lg:text-3xl">
-            {toptext || ''}
-          </h2>
+          {toptext &&
+              <h2 className="mb-4 text-center text-2xl text-h1title md:mb-6 lg:text-3xl">
+                {toptext}
+              </h2>
+          }
           <h2 className="mb-4 text-center text-2xl text-h1title md:mb-6 lg:text-3xl">
             {header}
           </h2>


### PR DESCRIPTION
Hey, this is just a small tweak (optional but recommended).

If you use an empty string (`{string || ''}`), it will always render that H2 even if there's nothing inside it. You'll just be left with an empty H2 tag, which can still having spacing:

![Landing page DatoCMS Starter](https://github.com/Kremhjem/datocms-moicon-2/assets/11964962/1d227b8c-35c8-4836-bcf5-fba7a55175df)

(And if you have enough of them, like in an iterator/loop, you may eventually affect render performance). It's usually cleaner to just leave out that element altogether by hiding the whole thing conditionally. Up to you though!